### PR TITLE
fix texture atlas size check error, and add a bin script for generati…

### DIFF
--- a/aicsimageprocessing/bin/make_atlas.py
+++ b/aicsimageprocessing/bin/make_atlas.py
@@ -62,9 +62,6 @@ def main():
         atlas_group = textureAtlas.generate_texture_atlas(
             image, name=name, max_edge=2048, pack_order=None
         )
-        atlas_group.dims.pixel_size_x = 1.0
-        atlas_group.dims.pixel_size_y = 1.0
-        atlas_group.dims.pixel_size_z = 4.0
         atlas_group.save(args.outdir)
     except Exception as e:
         log.error("=============================================")

--- a/aicsimageprocessing/bin/make_atlas.py
+++ b/aicsimageprocessing/bin/make_atlas.py
@@ -1,0 +1,80 @@
+import argparse
+import logging
+import os
+import sys
+import traceback
+
+from aicsimageprocessing import get_module_version, textureAtlas
+from aicsimageio import AICSImage
+
+###############################################################################
+
+log = logging.getLogger()
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s - %(name)s - %(lineno)3d][%(levelname)s] %(message)s",
+)
+
+###############################################################################
+
+
+class Args(argparse.Namespace):
+    def __init__(self):
+        # Arguments that could be passed in through the command line
+        self.debug = False
+        #
+        self.__parse()
+
+    def __parse(self):
+        p = argparse.ArgumentParser(
+            prog="make_atlas",
+            description="Make a volume-viewer texture atlas from a ome-tiff",
+        )
+        p.add_argument(
+            "-v",
+            "--version",
+            action="version",
+            version="%(prog)s " + get_module_version(),
+        )
+
+        p.add_argument(
+            "--debug", action="store_true", dest="debug", help=argparse.SUPPRESS
+        )
+
+        p.add_argument("infile", type=str, help="input zstack")
+        p.add_argument("outdir", type=str, help="output directory")
+
+        p.parse_args(namespace=self)
+
+
+###############################################################################
+
+
+def main():
+    try:
+        args = Args()
+
+        dbg = args.debug
+        image = AICSImage(args.infile)
+        # preload for performance
+        image.data
+        name = os.path.splitext(os.path.basename(args.infile))[0]
+        atlas_group = textureAtlas.generate_texture_atlas(
+            image, name=name, max_edge=2048, pack_order=None
+        )
+        atlas_group.dims.pixel_size_x = 1.0
+        atlas_group.dims.pixel_size_y = 1.0
+        atlas_group.dims.pixel_size_z = 4.0
+        atlas_group.save(args.outdir)
+    except Exception as e:
+        log.error("=============================================")
+        if dbg:
+            log.error("\n\n" + traceback.format_exc())
+            log.error("=============================================")
+        log.error("\n\n" + str(e) + "\n")
+        log.error("=============================================")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/aicsimageprocessing/textureAtlas.py
+++ b/aicsimageprocessing/textureAtlas.py
@@ -207,9 +207,15 @@ class TextureAtlasGroup:
         if atlas.atlas.shape is None:
             return False
         shape = atlas.atlas.shape
-        if self.dims.atlas_width != shape[2]:
+        if self.dims.atlas_width != shape[1]:
+            print(
+                f"width mismatch atlas_width={self.dims.atlas_width} but shape is {shape[1]}"
+            )
             return False
-        if self.dims.atlas_height != shape[1]:
+        if self.dims.atlas_height != shape[2]:
+            print(
+                f"height mismatch atlas_height={self.dims.atlas_height} but shape is {shape[2]}"
+            )
             return False
         return True
 

--- a/aicsimageprocessing/textureAtlas.py
+++ b/aicsimageprocessing/textureAtlas.py
@@ -209,12 +209,14 @@ class TextureAtlasGroup:
         shape = atlas.atlas.shape
         if self.dims.atlas_width != shape[1]:
             print(
-                f"width mismatch atlas_width={self.dims.atlas_width} but shape is {shape[1]}"
+                f"width mismatch atlas_width={self.dims.atlas_width}"
+                f" but shape is {shape[1]}"
             )
             return False
         if self.dims.atlas_height != shape[2]:
             print(
-                f"height mismatch atlas_height={self.dims.atlas_height} but shape is {shape[2]}"
+                f"height mismatch atlas_height={self.dims.atlas_height}"
+                f" but shape is {shape[2]}"
             )
             return False
         return True

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,8 @@ setup(
     ),
     entry_points={
         "console_scripts": [
-            "make_thumbnail=aicsimageprocessing.bin.make_thumbnail:main"
+            "make_thumbnail=aicsimageprocessing.bin.make_thumbnail:main",
+            "make_atlas=aicsimageprocessing.bin.make_atlas:main",
         ],
     },
     install_requires=requirements,


### PR DESCRIPTION
…ng a single texture atlas

I wanted to generate some texture atlases for volume-viewer in a small batch and noticed that I was getting some unexpected errors.  The size check was incorrectly swapping width and height.

Added a command line script to generate a single texture atlas for one volume file.  Input is file path, output is directory in which to store the atlas files.  The output files will be named according to the name of the input file.