### PR TITLE
update to aicsimageio 4.1

### DIFF
--- a/aicsimageprocessing/bin/make_atlas.py
+++ b/aicsimageprocessing/bin/make_atlas.py
@@ -56,13 +56,14 @@ def main():
 
         dbg = args.debug
         image = AICSImage(args.infile)
-        # preload for performance
-        image.data
-        name = os.path.splitext(os.path.basename(args.infile))[0]
-        atlas_group = textureAtlas.generate_texture_atlas(
-            image, name=name, max_edge=2048, pack_order=None
-        )
-        atlas_group.save(args.outdir)
+        for i in range(0, image.dims.T):
+            name = os.path.splitext(os.path.basename(args.infile))[0]
+            if image.dims.T > 0:
+                name = f"{name}_{i}"
+            atlas_group = textureAtlas.generate_texture_atlas(
+                image, name=name, max_edge=2048, pack_order=None, t=i
+            )
+            atlas_group.save(args.outdir)
     except Exception as e:
         log.error("=============================================")
         if dbg:

--- a/aicsimageprocessing/bin/make_thumbnail.py
+++ b/aicsimageprocessing/bin/make_thumbnail.py
@@ -45,6 +45,7 @@ class Args(argparse.Namespace):
         p.add_argument("--size", type=int, help="size", default=128)
         p.add_argument("--mask", type=int, help="mask channel", default=-1)
         p.add_argument("--axis", type=int, help="axis 0, 1, or 2", default=2)
+        p.add_argument("--time", type=int, help="time index", default=0)
         p.add_argument(
             "--channels", type=int, nargs="+", help="channels to composite", default=[0]
         )
@@ -84,6 +85,7 @@ def main():
             axis=args.axis,
             apply_mask=(args.mask != -1),
             mask_channel=args.mask,
+            t=args.time
         )
     except Exception as e:
         log.error("=============================================")

--- a/aicsimageprocessing/isosurfaceGenerator.py
+++ b/aicsimageprocessing/isosurfaceGenerator.py
@@ -15,9 +15,9 @@ class Mesh:
     Examples
     --------
     >>> image = AICSImage("some/bio/image.ome.tif")
-    ... mesh0 = generate_mesh(image, isovalue=0, channel=0)
+    ... mesh0 = generate_mesh(image.data, isovalue=0, channel=0)
     ... # will generate a different mesh due to the different isovalue
-    ... mesh1 = generate_mesh(image, isovalue=1, channel=0)
+    ... mesh1 = generate_mesh(image.data, isovalue=1, channel=0)
     ... mesh0.save_as_obj("some/bio/image/mesh.obj")
     ... # mesh.obj can be imported into 3D viewers and represents a 3D rendering of
     ... # image.ome.tif
@@ -78,7 +78,7 @@ def generate_mesh(image, isovalue=0, channel=0):
     """
     if not isinstance(image, AICSImage):
         raise ValueError("Meshes can only be generated with AICSImage objects!")
-    if channel >= image.size_c:
+    if channel >= image.dims.C:
         raise IndexError(
             "Channel provided for mesh generation is out of bounds for image data!"
         )

--- a/aicsimageprocessing/tests/test_TextureAtlas.py
+++ b/aicsimageprocessing/tests/test_TextureAtlas.py
@@ -8,61 +8,56 @@ from aicsimageprocessing.textureAtlas import generate_texture_atlas
 
 
 class TestTextureAtlas(unittest.TestCase):
-    # @unittest.skip("temporarily disabled")
     def test_Save(self):
-        image = AICSImage("aicsimageprocessing/tests/img/img40_1.ome.tif", reader=ome_tiff_reader.OmeTiffReader)
+        image = AICSImage("aicsimageprocessing/tests/img/img40_1.ome.tif")
         atlas = generate_texture_atlas(
             im=image,
             pack_order=[[0, 1, 2], [3], [4]],
-            prefix="test_Sizing",
+            name="test_Sizing",
             max_edge=1024,
         )
         atlas.save("img/atlas_max")
-        image.close()
 
-    # @unittest.skip("temporarily disabled")
     def test_Sizing(self):
         # arrange
-        with AICSImage("aicsimageprocessing/tests/img/img40_1.ome.tif") as image:
-            max_edge = 2048
-            # act
-            atlas = generate_texture_atlas(
-                im=image,
-                prefix="test_Sizing",
-                max_edge=max_edge,
-                pack_order=[[3, 2, 1, 0], [4]],
-            )
+        image = AICSImage("aicsimageprocessing/tests/img/img40_1.ome.tif")
+        max_edge = 2048
+        # act
+        atlas = generate_texture_atlas(
+            im=image,
+            name="test_Sizing",
+            max_edge=max_edge,
+            pack_order=[[3, 2, 1, 0], [4]],
+        )
         atlas_maxedge = max(atlas.dims.atlas_width, atlas.dims.atlas_height)
         # assert
         self.assertTrue(atlas_maxedge <= max_edge)
 
-    # @unittest.skip("temporarily disabled")
     def test_pickChannels(self):
         packing_list = [[0], [1, 2], [3, 4]]
         # arrange
-        with AICSImage("aicsimageprocessing/tests/img/img40_1.ome.tif") as image:
-            # act
-            atlas = generate_texture_atlas(
-                image, prefix="test_pickChannels", pack_order=packing_list
-            )
-            # returns as dict
-            # metadata = atlas.get_metadata()
-            # returns list of dicts
-            image_dicts = atlas.atlas_list
-            output_packed = [img.metadata["channels"] for img in image_dicts]
+        image = AICSImage("aicsimageprocessing/tests/img/img40_1.ome.tif")
+        # act
+        atlas = generate_texture_atlas(
+            image, name="test_pickChannels", pack_order=packing_list
+        )
+        # returns as dict
+        # metadata = atlas.get_metadata()
+        # returns list of dicts
+        image_dicts = atlas.atlas_list
+        output_packed = [img.metadata["channels"] for img in image_dicts]
         # assert
         self.assertEqual(packing_list, output_packed)
 
-    # @unittest.skip("temporarily disabled")
     def test_metadata(self):
         packing_list = [[0], [1, 2], [3, 4]]
         prefix = "atlas"
         # arrange
-        with AICSImage("aicsimageprocessing/tests/img/img40_1.ome.tif") as image:
-            # act
-            atlas = generate_texture_atlas(
-                image, prefix=prefix, pack_order=packing_list
-            )
+        image = AICSImage("aicsimageprocessing/tests/img/img40_1.ome.tif")
+        # act
+        atlas = generate_texture_atlas(
+            image, name=prefix, pack_order=packing_list
+        )
         # assert
         metadata = atlas.get_metadata()
         self.assertTrue(

--- a/aicsimageprocessing/tests/test_TextureAtlas.py
+++ b/aicsimageprocessing/tests/test_TextureAtlas.py
@@ -3,25 +3,27 @@
 import unittest
 
 from aicsimageio import AICSImage
+from aicsimageio.readers import ome_tiff_reader
 from aicsimageprocessing.textureAtlas import generate_texture_atlas
 
 
 class TestTextureAtlas(unittest.TestCase):
-    @unittest.skip("temporarily disabled")
+    # @unittest.skip("temporarily disabled")
     def test_Save(self):
-        with AICSImage("img/img40_1.ome.tif") as image:
-            atlas = generate_texture_atlas(
-                im=image,
-                pack_order=[[0, 1, 2], [3], [4]],
-                prefix="test_Sizing",
-                max_edge=1024,
-            )
+        image = AICSImage("aicsimageprocessing/tests/img/img40_1.ome.tif", reader=ome_tiff_reader.OmeTiffReader)
+        atlas = generate_texture_atlas(
+            im=image,
+            pack_order=[[0, 1, 2], [3], [4]],
+            prefix="test_Sizing",
+            max_edge=1024,
+        )
         atlas.save("img/atlas_max")
+        image.close()
 
-    @unittest.skip("temporarily disabled")
+    # @unittest.skip("temporarily disabled")
     def test_Sizing(self):
         # arrange
-        with AICSImage("img/img40_1.ome.tif") as image:
+        with AICSImage("aicsimageprocessing/tests/img/img40_1.ome.tif") as image:
             max_edge = 2048
             # act
             atlas = generate_texture_atlas(
@@ -34,11 +36,11 @@ class TestTextureAtlas(unittest.TestCase):
         # assert
         self.assertTrue(atlas_maxedge <= max_edge)
 
-    @unittest.skip("temporarily disabled")
+    # @unittest.skip("temporarily disabled")
     def test_pickChannels(self):
         packing_list = [[0], [1, 2], [3, 4]]
         # arrange
-        with AICSImage("img/img40_1.ome.tif") as image:
+        with AICSImage("aicsimageprocessing/tests/img/img40_1.ome.tif") as image:
             # act
             atlas = generate_texture_atlas(
                 image, prefix="test_pickChannels", pack_order=packing_list
@@ -51,12 +53,12 @@ class TestTextureAtlas(unittest.TestCase):
         # assert
         self.assertEqual(packing_list, output_packed)
 
-    @unittest.skip("temporarily disabled")
+    # @unittest.skip("temporarily disabled")
     def test_metadata(self):
         packing_list = [[0], [1, 2], [3, 4]]
         prefix = "atlas"
         # arrange
-        with AICSImage("img/img40_1.ome.tif") as image:
+        with AICSImage("aicsimageprocessing/tests/img/img40_1.ome.tif") as image:
             # act
             atlas = generate_texture_atlas(
                 image, prefix=prefix, pack_order=packing_list

--- a/aicsimageprocessing/textureAtlas.py
+++ b/aicsimageprocessing/textureAtlas.py
@@ -179,7 +179,7 @@ class TextureAtlasGroup:
         dims.channels = aics_image.dims.C
         dims.tiles = aics_image.dims.Z
 
-        channel_names = aics_image.get_channel_names()
+        channel_names = aics_image.channel_names
         if channel_names is not None:
             dims.channel_names = channel_names
         else:
@@ -265,7 +265,7 @@ class TextureAtlasGroup:
             # add this name to the atlas's metadata for use in get_metadata below.
             atlas.metadata["name"] = atlasname
             full_path = os.path.join(output_dir, atlasname)
-            TwoDWriter.save(atlas.atlas, full_path)
+            TwoDWriter.save(atlas.atlas, full_path, dim_order="SYX")
             i += 1
 
         metadata = self.get_metadata()

--- a/aicsimageprocessing/textureAtlas.py
+++ b/aicsimageprocessing/textureAtlas.py
@@ -265,7 +265,7 @@ class TextureAtlasGroup:
             # add this name to the atlas's metadata for use in get_metadata below.
             atlas.metadata["name"] = atlasname
             full_path = os.path.join(output_dir, atlasname)
-            TwoDWriter.save(atlas.atlas, full_path, dim_order="SYX")
+            TwoDWriter.save(atlas.atlas, full_path, dim_order="SXY")
             i += 1
 
         metadata = self.get_metadata()

--- a/aicsimageprocessing/thumbnailGenerator.py
+++ b/aicsimageprocessing/thumbnailGenerator.py
@@ -8,6 +8,7 @@ import platform
 from typing import List, Sequence, Tuple, Union
 
 import aicsimageio
+from aicsimageio.writers.two_d_writer import TwoDWriter
 import numpy as np
 import skimage.transform
 from PIL import Image, ImageDraw, ImageFont
@@ -481,8 +482,9 @@ def make_one_thumbnail(
     else:
         raise ValueError(f"Unknown axis value: {axis}")
 
-    with aicsimageio.AICSImage(infile) as image:
-        imagedata = image.get_image_data("CZYX", T=0)
+    image = aicsimageio.AICSImage(infile)
+    imagedata = image.get_image_data("CZYX", T=0)
+
     generator = ThumbnailGenerator(
         channel_indices=channels,
         size=size,
@@ -507,8 +509,5 @@ def make_one_thumbnail(
         thumbnail = np.array(img)
         thumbnail = thumbnail.transpose(2, 0, 1)
 
-    with aicsimageio.writers.PngWriter(
-        file_path=outfile, overwrite_file=True
-    ) as writer:
-        writer.save(thumbnail)
+    TwoDWriter.save(thumbnail, outfile)
     return thumbnail

--- a/aicsimageprocessing/thumbnailGenerator.py
+++ b/aicsimageprocessing/thumbnailGenerator.py
@@ -471,6 +471,7 @@ def make_one_thumbnail(
     apply_mask: bool = False,
     mask_channel: int = 0,
     label: str = "",
+    t: int = 0
 ):
     axistranspose = (1, 0, 2, 3)
     if axis == 2:  # Z
@@ -483,7 +484,7 @@ def make_one_thumbnail(
         raise ValueError(f"Unknown axis value: {axis}")
 
     image = aicsimageio.AICSImage(infile)
-    imagedata = image.get_image_data("CZYX", T=0)
+    imagedata = image.get_image_data("CZYX", T=t)
 
     generator = ThumbnailGenerator(
         channel_indices=channels,
@@ -509,5 +510,5 @@ def make_one_thumbnail(
         thumbnail = np.array(img)
         thumbnail = thumbnail.transpose(2, 0, 1)
 
-    TwoDWriter.save(thumbnail, outfile)
+    TwoDWriter.save(thumbnail, outfile, dim_order="SXY")
     return thumbnail

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ interactive_requirements = [
 ]
 
 requirements = [
-    "aicsimageio>=3.1.2",
+    "aicsimageio>=4.1.0",
     "matplotlib>=3.1.1",
     "numpy>=1.16.4",
     "Pillow>=5.2.0",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ interactive_requirements = [
 ]
 
 requirements = [
-    "aicsimageio>=4.1.0",
+    "aicsimageio[all]>=4.1.0",
     "matplotlib>=3.1.1",
     "numpy>=1.16.4",
     "Pillow>=5.2.0",


### PR DESCRIPTION
This updates all usage of aicsimageio to 4.1 in this repo.
Also reinstates some previously disabled tests.
As a bonus, also improve time series handling in the make_atlas and make_thumbnail scripts. (Essentially making t a new parameter)