### PR TITLE
Deprecation notice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# DEPRECATED
+This library is no longer being maintained due to low usage.
+
 # aicsimageprocessing
 
 [![Build Status](https://github.com/AllenCellModeling/aicsimageprocessing/workflows/Build%20Master/badge.svg)](https://github.com/AllenCellModeling/aicsimageprocessing/actions)


### PR DESCRIPTION
This repository has no maintainers. Some of our AICS code depends on it, but no new usage is recommended.

Existing uses:
* The [Allen Cell Toolkit](https://github.com/AllenCellModeling/actk) (not currently maintained)
* The [Cytodata Hackathon repo](https://github.com/AllenCell/cytodata-hackathon-base) (not currently maintained)
* [nuc_morph_analysis](https://github.com/aics-int/nuc-morph-analysis/) (but @ritvikvasan says we don't need it any more)
* One of @toloudis's repos, but he can move the code he needs into that repo